### PR TITLE
Styling on rider pages + github contribution link

### DIFF
--- a/pages/five-boro/jaan.mdx
+++ b/pages/five-boro/jaan.mdx
@@ -4,7 +4,12 @@ description: I am raising money for the One Fact Foundation to reduce the price 
 authors: Jaan Altosaar Li, PhD
 ---
 
+import { Bleed } from 'nextra-theme-docs'
+import Image from 'next/image'
 import {YouTube} from 'mdx-embed'
+
+# I need help building AI that helps
+I am raising money for the One Fact Foundation to reduce the price of health care using open source AI.
 
 [Edit this page or propose changes](https://github.com/onefact/onefact.org/edit/main/pages/five-boro-bike-tour/jaan.md)
 
@@ -52,7 +57,9 @@ Galvanized, I knew I needed a lot more help than I had access to, and started ta
 
 My friends Susan, Brad, Rohan, Maxim and I applied to the Magic Grant program with this video: 
 
-<YouTube youTubeId="gLEJ1m0fY-o" />
+<Bleed>
+    <YouTube youTubeId="gLEJ1m0fY-o" />
+</Bleed>
 
 In it, we describe why we need to start a nonprofit to be able to use artificial intelligence models to collect, standardize, and distribute the hundreds of terabytes of the hospital prices that are public by law - to reduce increase the power of patients to shop for quality health care they can afford.
 

--- a/pages/five-boro/jaan.mdx
+++ b/pages/five-boro/jaan.mdx
@@ -5,13 +5,19 @@ authors: Jaan Altosaar Li, PhD
 ---
 
 import { Bleed } from 'nextra-theme-docs'
+import { Card, Cards } from 'nextra/components'
 import Image from 'next/image'
-import {YouTube} from 'mdx-embed'
+import { YouTube } from 'mdx-embed'
+
+<style global jsx>{`
+  img {
+    aspect-ratio: 12/6.3;
+    object-fit: contain;
+  }
+`}</style>
 
 # I need help building AI that helps
 I am raising money for the One Fact Foundation to reduce the price of health care using open source AI.
-
-[Edit this page or propose changes](https://github.com/onefact/onefact.org/edit/main/pages/five-boro-bike-tour/jaan.md)
 
 ![Jaan](/images/jaan.jpg "Jaan")
 

--- a/style.css
+++ b/style.css
@@ -48,3 +48,5 @@ code.text-\[\.9em\] {
     display: none;
   }
 }
+
+

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -45,9 +45,9 @@ const logo = (
 
 const config: DocsThemeConfig = {
   project: {
-    link: 'https://github.com/shuding/nextra'
+    link: 'https://github.com/onefact/new.onefact.org'
   },
-  docsRepositoryBase: 'https://github.com/shuding/nextra/tree/main/docs',
+  docsRepositoryBase: 'https://github.com/onefact/new.onefact.org/tree/main/',
   useNextSeoProps() {
     const { asPath } = useRouter()
     if (asPath !== '/') {


### PR DESCRIPTION
Rider page styling:
- added title in .mdx, separate from frontmatter data
- added bleed styling for embeds (e.g. youtube)
- resized built-in Next.js image component through global styling

Github contribution link:
- Removed link from top of article
- Configured generic github edit/feedback link to render at the end of side table of contents

**Note**: github contribution link will be generated automatically and redirect to the file of the specific page currently visited. No need to manually insert the link as part of the contents of each page!